### PR TITLE
align date formats

### DIFF
--- a/test_ystockquote.py
+++ b/test_ystockquote.py
@@ -43,7 +43,7 @@ class YStockQuoteTestCase(unittest.TestCase):
 
     def test_get_historical_prices(self):
         prices = ystockquote.get_historical_prices(
-            self.symbol, '20130102', '20130115'
+            self.symbol, '2013-01-02', '2013-01-15'
         )
         headers = [
             'Date', 'Open', 'High', 'Low', 'Close', 'Volume', 'Adj Close'

--- a/ystockquote.py
+++ b/ystockquote.py
@@ -147,17 +147,17 @@ def get_short_ratio(symbol):
 def get_historical_prices(symbol, start_date, end_date):
     """
     Get historical prices for the given ticker symbol.
-    Date format is 'YYYYMMDD'
+    Date format is 'YYYY-MM-DD'
 
     Returns a nested list (first item is list of column headers).
     """
     params = urlencode({
         's': symbol,
-        'a': int(start_date[4:6]) - 1,
-        'b': int(start_date[6:8]),
+        'a': int(start_date[5:7]) - 1,
+        'b': int(start_date[8:10]),
         'c': int(start_date[0:4]),
-        'd': int(end_date[4:6]) - 1,
-        'e': int(end_date[6:8]),
+        'd': int(end_date[5:7]) - 1,
+        'e': int(end_date[8:10]),
         'f': int(end_date[0:4]),
         'g': 'd',
         'ignore': '.csv',


### PR DESCRIPTION
This changes the date format to be consistently '[YYYY]-[MM]-[DD]'. It does, however, break the API, but I think supporting both formats would be overly complex - "There should be one-- and preferably only one --obvious way to do it."
