### PR TITLE
Added Optional Support For List Of Dictionaries for get_historical_prices

### DIFF
--- a/ystockquote.py
+++ b/ystockquote.py
@@ -15,7 +15,6 @@
 
 __version__ = '0.2.4'
 
-
 try:
     # py3
     from urllib.request import Request, urlopen
@@ -144,7 +143,7 @@ def get_short_ratio(symbol):
     return _request(symbol, 's7')
 
 
-def get_historical_prices(symbol, start_date, end_date):
+def get_historical_prices(symbol, start_date, end_date,list_dicts=False):
     """
     Get historical prices for the given ticker symbol.
     Date format is 'YYYY-MM-DD'
@@ -167,4 +166,22 @@ def get_historical_prices(symbol, start_date, end_date):
     resp = urlopen(req)
     content = str(resp.read().decode('utf-8').strip())
     days = content.splitlines()
-    return [day.split(',') for day in days]
+   
+    if(list_dicts):
+        hist_data = list() 
+        keys = days[0].split(',')
+        for day in days[1:]:
+            day_data = day.split(',')
+            day_dict = {day_data[0]:
+                            {keys[1]:day_data[1],
+                             keys[2]:day_data[2],
+                             keys[3]:day_data[3],
+                             keys[4]:day_data[4],
+                             keys[5]:day_data[5],
+                             keys[6]:day_data[6]
+                            }             
+                        }
+            hist_data.append(day_dict)
+        return hist_data
+    else:
+        return [day.split(',') for day in days]


### PR DESCRIPTION
Hi Corey,

Thanks a lot for sharing your module . I have added  a optional argument to get_historical_prices() to allow for results to be returned as a list of dictionaries without breaking the current module for other users.

Could you merge into your module and push update to  PyPi when you have the time ?

```
>>> list_dict = ystockquote.get_historical_prices('GOOG', '2013-01-03', '2013-01-08',list_dicts=True)
>>> just_list = ystockquote.get_historical_prices('GOOG', '2013-01-03', '2013-01-08')
>>> just_list
[['Date', 'Open', 'High', 'Low', 'Close', 'Volume', 'Adj Close'], ['2013-01-08', '735.54', '736.30', '724.43', '733.30', '1676100', '733.30'], ['2013-01-07', '735.45', '739.38', '730.58', '734.75', '1655700', '734.75'], ['2013-01-04', '729.34', '741.47', '727.68', '737.97', '2763500', '737.97'], ['2013-01-03', '724.93', '731.93', '720.72', '723.67', '2318200', '723.67']]
>>> list_dict
[{'2013-01-08': {'Volume': '1676100', 'Adj Close': '733.30', 'High': '736.30', 'Low': '724.43', 'Close': '733.30', 'Open': '735.54'}}, {'2013-01-07': {'Volume': '1655700', 'Adj Close': '734.75', 'High': '739.38', 'Low': '730.58', 'Close': '734.75', 'Open': '735.45'}}, {'2013-01-04': {'Volume': '2763500', 'Adj Close': '737.97', 'High': '741.47', 'Low': '727.68', 'Close': '737.97', 'Open': '729.34'}}, {'2013-01-03': {'Volume': '2318200', 'Adj Close': '723.67', 'High': '731.93', 'Low': '720.72', 'Close': '723.67', 'Open': '724.93'}}]
>>> import pprint
>>> pprint.pprint(list_dict)
[{'2013-01-08': {'Adj Close': '733.30',
                 'Close': '733.30',
                 'High': '736.30',
                 'Low': '724.43',
                 'Open': '735.54',
                 'Volume': '1676100'}},
 {'2013-01-07': {'Adj Close': '734.75',
                 'Close': '734.75',
                 'High': '739.38',
                 'Low': '730.58',
                 'Open': '735.45',
                 'Volume': '1655700'}},
 {'2013-01-04': {'Adj Close': '737.97',
                 'Close': '737.97',
                 'High': '741.47',
                 'Low': '727.68',
                 'Open': '729.34',
                 'Volume': '2763500'}},
 {'2013-01-03': {'Adj Close': '723.67',
                 'Close': '723.67',
                 'High': '731.93',
                 'Low': '720.72',
                 'Open': '724.93',
                 'Volume': '2318200'}}]
```
