### PR TITLE
added get_historical_52_week_high method

### DIFF
--- a/test_ystockquote.py
+++ b/test_ystockquote.py
@@ -63,6 +63,15 @@ class YStockQuoteTestCase(TestWithScenarios):
         self.assertGreater(float(prices[end_date]['Volume']), 0.0)
         self.assertGreater(float(prices[end_date]['Adj Close']), 0.0)
 
+    def test_get_historical_52_week_high(self):
+        symbol = 'GOOG'
+        date = '2014-07-10'
+        prices = ystockquote.get_historical_52_week_high(symbol, date)
+        self.assertIsInstance(prices, dict)
+        self.assertGreater(len(prices), 1)
+        item = prices.popitem()
+        self.assertEqual(item[0], '2014-04-02')
+        self.assertEqual(item[1]['High'], 604.83)
 
 if __name__ == '__main__':
     unittest.main()

--- a/ystockquote.py
+++ b/ystockquote.py
@@ -2,6 +2,7 @@
 #  ystockquote : Python module - retrieve stock quote data from Yahoo Finance
 #
 #  Copyright (c) 2007,2008,2013 Corey Goldberg (cgoldberg@gmail.com)
+#  Copyright (c) 2014 Ilya Usvyatsky (usvyatsky@gmail.com)
 #
 #  license: GNU LGPL
 #
@@ -498,3 +499,25 @@ def get_historical_prices(symbol, start_date, end_date):
              keys[5]: day_data[5],
              keys[6]: day_data[6]}
     return hist_dict
+
+def get_historical_52_week_high(symbol, date):
+    """
+    Compute historical 52-week high for the given ticker symbol
+    at given date.
+    Date format is 'YYYY-MM-DD'
+
+    Returns a nested dictionary (dict of dicts).
+    outer dict keys are dates ('YYYY-MM-DD')
+    """
+    start_date = str(int(date[0:4])-1) + date[4:]
+    prices = get_historical_prices(symbol, start_date, date)
+    max_high = 0
+    for d in prices:
+        if prices[d]['High'] > max_high:
+            max_high = prices[d]['High']
+    result = {}
+    for d in prices:
+        if prices[d]['High'] == max_high:
+            result[d] = prices[d]
+    return result
+


### PR DESCRIPTION
This is a small enhancement to the package that computes historical 52-week high point(s) given a symbol and date. See issue #30 for definition I used for historical 52-week high in this implementation.
